### PR TITLE
[codex] Fix ribbon sync dropping graph buttons

### DIFF
--- a/src/App.cs
+++ b/src/App.cs
@@ -153,7 +153,13 @@ namespace Relay
             {
                 if (!e.Item.Id.Contains("relay")) return;
                 //set our current graph based on the click on the ribbon item
-                Globals.CurrentGraphToRun = e.Item.Description.GetStringBetweenCharacters('[', ']');
+                var metadata = e.Item.Description?.ToString();
+                if (string.IsNullOrWhiteSpace(metadata))
+                {
+                    metadata = e.Item.ToolTip?.ToString();
+                }
+
+                Globals.CurrentGraphToRun = metadata.GetStringBetweenCharacters('[', ']');
             }
             catch (Exception)
             {

--- a/src/Utilities/RibbonUtils.cs
+++ b/src/Utilities/RibbonUtils.cs
@@ -42,7 +42,8 @@ namespace Relay.Utilities
                     fInfo.Name.GenerateButtonText(),
                     Path.Combine(Globals.ExecutingPath, "Relay.dll"), "Relay.Run")
                 {
-                    ToolTip = tooltip
+                    ToolTip = tooltip,
+                    LongDescription = tooltip
                 };
               
                 //set the images, if there are none, use default
@@ -163,7 +164,9 @@ namespace Relay.Utilities
 
         public static void HideUnused()
         {
-            foreach (var key in Globals.RelayButtons.Keys)
+            var keysToRemove = new List<string>();
+
+            foreach (var key in Globals.RelayButtons.Keys.ToList())
             {
                 Globals.RelayButtons.TryGetValue(key, out RibbonItem ribbonItem);
 
@@ -175,8 +178,13 @@ namespace Relay.Utilities
                     if (File.Exists(path)) continue;
                     ribbonItem.Visible = false;
 
-                    Globals.RelayButtons.Remove(key);
+                    keysToRemove.Add(key);
                 }
+            }
+
+            foreach (var key in keysToRemove)
+            {
+                Globals.RelayButtons.Remove(key);
             }
 
             //now hide empty panels if there are any


### PR DESCRIPTION
## Summary
- Fix ribbon sync so it stops dropping graph buttons during refresh.
- Preserve the graph path metadata on ribbon items so the run command can resolve the selected `.dyn`.

## Validation
- `dotnet build src\Relay.sln -c "Debug R27"`
