### PR TITLE
Reconcile ribbon graph synchronization plan

### DIFF
--- a/openspec/changes/repair-ribbon-graph-synchronization/design.md
+++ b/openspec/changes/repair-ribbon-graph-synchronization/design.md
@@ -1,13 +1,15 @@
 ## Context
 
-`RibbonUtils.SyncGraphs` incrementally creates controls while `Globals.RelayButtons` and `Globals.RelayPanels` act as the in-memory index. `AddItems` replaces panel membership with only the latest stacked items, and `HideUnused` removes dictionary entries during enumeration. Autodesk controls can be hidden but not reliably removed from the ribbon.
+PR #35 established a safer baseline: root enumeration failure aborts synchronization, `TrackButton` appends successful controls to cumulative panel membership, and `HideUnused` enumerates a key snapshot before removing inactive mappings. Autodesk controls can still be hidden but not reliably removed from the ribbon.
+
+The remaining flow is not a complete reconciliation. `SyncGraphs` enumerates nested directories while creating host controls, `HideUnused` independently rechecks `File.Exists`, graph identity is recovered from tooltip text, and `Globals.RelayPanels` is keyed only by panel name. Once a graph is removed, its active mapping is discarded; if the same path returns, Relay creates another host control instead of deliberately reactivating the historical one.
 
 ## Goals / Non-Goals
 
 **Goals:**
 
 - Make repeated synchronization idempotent for an unchanged filesystem.
-- Reconcile discovered paths, button mappings, and panel visibility as one state transition.
+- Reconcile discovered paths, button mappings, historical controls, and panel visibility as one state transition.
 - Keep filesystem comparison logic testable without Revit.
 
 **Non-Goals:**
@@ -17,21 +19,23 @@
 
 ## Decisions
 
-1. Build an immutable discovery snapshot before touching the ribbon. The snapshot contains normalized graph paths grouped by tab and panel. This avoids partially mutating host UI while enumeration is still failing. The alternative, updating globals during directory traversal, preserves the current partial-state risk.
-2. Reconcile snapshots against a typed registry. Existing mappings remain when their paths are present; missing paths are hidden and removed from active lookup only after enumeration; new paths are created and appended to complete panel membership. The alternative of replacing each panel list loses existing controls.
-3. Keep hidden historical controls in a separate host-item record when required by Revit, while active graph lookup contains only current paths. This reflects the host limitation instead of treating hidden controls as deleted.
-4. Store the graph path in both Relay's registry and ribbon metadata needed by Autodesk events. Tooltip remains presentation text, not the source of identity.
+1. Build an immutable discovery snapshot before touching the ribbon. The snapshot contains normalized graph paths grouped by a typed tab-and-panel identity. All applicable directories must enumerate successfully before the snapshot is eligible for reconciliation. The alternative, updating globals during directory traversal, preserves partial-state risk.
+2. Compare the completed snapshot with a typed registry to produce a pure reconciliation plan: unchanged, add, deactivate, and reactivate. Apply that plan to Revit only after comparison succeeds. The alternative, combining comparison with host mutation, cannot be tested reliably and can leave partial UI state.
+3. Keep active graph lookup separate from historical host controls. A removed graph leaves a hidden historical record; the same normalized path reuses and reveals that control when host behavior permits. A new path creates a new control. This reflects Revit's removal limitation instead of treating hidden controls as deleted.
+4. Identify panel membership by both tab and panel name. Panel visibility is derived from every active mapping in that identity, avoiding collisions when different tabs use the same panel name.
+5. Store normalized graph paths and control identity in Relay-owned registry state. Ribbon tooltip and description remain presentation metadata and are not used by synchronization as the source of graph identity. Deterministic command activation remains scoped to the separate `route-ribbon-commands-deterministically` change.
 
 ## Risks / Trade-offs
 
-- [Ribbon controls accumulate after many renames] -> Reuse a stable path identity where possible and document that Revit cannot remove controls during a session.
+- [Ribbon controls accumulate after many unique renames] -> Reactivate stable-path controls where possible and retain only the historical host reference required by Revit.
 - [Directory enumeration fails midway] -> Do not apply a new snapshot unless discovery for the relevant root completes successfully.
-- [Host wrappers expose visibility differently] -> Centralize visibility updates and verify them in Revit 2025-2027.
+- [A Revit version cannot reveal a hidden control safely] -> Centralize visibility operations, fall back to creating one replacement mapping, and verify behavior in Revit 2025-2027.
+- [Existing panel names collide across tabs] -> Use a composite tab-and-panel identity in registry and reconciliation models.
 
 ## Migration Plan
 
-Replace the current dictionaries with the typed registry during startup. No persisted data migration is needed; state is rebuilt on every Revit session. Rollback restores the prior in-memory implementation.
+Introduce the pure snapshot and reconciliation models behind the existing explicit/startup Sync entry points, then replace direct global dictionary cleanup with the typed registry. No persisted data migration is needed; state is rebuilt on every Revit session. Rollback restores the PR #35 in-memory implementation.
 
 ## Open Questions
 
-- Whether Revit permits safely reusing a hidden control after a graph is deleted and recreated at the same path must be confirmed in host testing.
+- Whether every supported Revit version permits safely revealing a hidden control after a graph is deleted and recreated at the same path must be confirmed in host testing.

--- a/openspec/changes/repair-ribbon-graph-synchronization/proposal.md
+++ b/openspec/changes/repair-ribbon-graph-synchronization/proposal.md
@@ -1,17 +1,17 @@
 ## Why
 
-Syncing graphs can throw while removing dictionary entries during enumeration and can lose panel membership when only newly created buttons are recorded. The result is a user-visible ribbon that hides valid graph buttons or entire panels after a sync.
+PR #35 stopped Sync Graphs from mutating its button dictionary during enumeration and made new controls append to panel membership. The remaining implementation still discovers and mutates ribbon state in one host-bound traversal, derives graph identity from presentation metadata, and cannot reliably reactivate a historical control when a graph returns.
 
 ## Problem
 
-Relay treats incremental additions as the complete panel state, mutates the button registry while iterating it, and derives graph identity from tooltip text that is not consistently available through Autodesk ribbon events.
+Relay has no complete discovery snapshot or typed reconciliation model. It compares individual files against global dictionaries while creating controls, keys panels only by panel name, and removes missing paths from active lookup without retaining enough identity to reuse their hidden controls.
 
 ## Scope
 
-- Reconcile discovered graph paths with existing ribbon state without removing live entries during enumeration.
-- Preserve complete panel membership across repeated syncs.
+- Build a complete, normalized discovery snapshot before changing ribbon state.
+- Reconcile that snapshot against typed tab, panel, graph, and historical-control state.
 - Hide only buttons whose graph no longer exists and hide a panel only when all tracked buttons are hidden.
-- Restore panels and buttons when valid content remains or is added.
+- Restore panels and reuse historical controls when valid content remains or returns at the same path.
 
 ## Non-goals
 
@@ -21,10 +21,11 @@ Relay treats incremental additions as the complete panel state, mutates the butt
 
 ## What Changes
 
-- Replace in-loop registry mutation with a reconciliation pass.
-- Merge newly created items into panel state rather than replacing prior membership.
-- Ensure graph metadata remains available to both Revit and Autodesk ribbon representations.
-- Add focused tests for discovery and reconciliation logic outside the Revit host.
+- Extract complete graph discovery and snapshot comparison from `RibbonUtils.SyncGraphs`.
+- Replace global dictionary cleanup with a typed, two-phase reconciliation plan.
+- Identify panels by tab and panel, and keep graph identity independent from tooltip or description text.
+- Reactivate reusable historical controls when a graph returns at the same normalized path.
+- Extend the existing Relay test project with focused discovery and reconciliation coverage.
 
 ## Capabilities
 
@@ -39,6 +40,7 @@ None.
 ## Risks
 
 - Autodesk ribbon items cannot be physically removed, so hidden controls must remain tracked correctly.
+- Reusing a hidden control may expose host-version differences and requires Revit verification.
 - Revit ribbon API behavior may differ between supported host versions.
 
 ## Compatibility
@@ -47,4 +49,4 @@ Applies to Revit 2025, 2026, and 2027. No Dynamo API behavior is changed.
 
 ## Impact
 
-Primarily affects `src/Utilities/RibbonUtils.cs`, `src/Utilities/Globals.cs`, and tests for pure graph-state reconciliation.
+Primarily affects `src/Utilities/RibbonUtils.cs`, `src/Utilities/Globals.cs`, new pure synchronization models, and `tests/Relay.Tests`. PR #35 already supplies safe dictionary enumeration, cumulative panel membership, failed-root preservation, and the reusable test project baseline.

--- a/openspec/changes/repair-ribbon-graph-synchronization/specs/ribbon-graph-synchronization/spec.md
+++ b/openspec/changes/repair-ribbon-graph-synchronization/specs/ribbon-graph-synchronization/spec.md
@@ -2,11 +2,12 @@
 
 ### Requirement: Synchronization discovers a complete graph snapshot
 
-Relay SHALL discover normalized `.dyn` paths grouped by their configured tab and panel before changing ribbon state.
+Relay SHALL discover normalized `.dyn` paths grouped by typed tab and panel identity before changing ribbon state.
 
 #### Scenario: Discovery succeeds
 - **WHEN** the configured graph tree can be enumerated
 - **THEN** Relay produces one complete snapshot of applicable graphs for the active Revit version
+- **AND** Relay changes no ribbon state until that snapshot is complete
 
 #### Scenario: Discovery fails
 - **WHEN** an applicable directory cannot be enumerated
@@ -36,9 +37,14 @@ Relay SHALL add newly discovered graphs and hide only controls whose mapped grap
 - **THEN** synchronization hides that graph's control
 - **AND** removes its path from active graph lookup after reconciliation
 
+#### Scenario: Graph returns at the same path
+- **WHEN** a graph previously removed from a complete snapshot returns at the same normalized path
+- **THEN** synchronization reactivates its historical control when the host supports reuse
+- **AND** maintains exactly one active mapping for that graph path
+
 ### Requirement: Panel visibility reflects complete membership
 
-Relay SHALL evaluate panel visibility from all tracked controls in that panel rather than only controls created by the latest synchronization.
+Relay SHALL evaluate panel visibility from all tracked controls in the same tab-and-panel identity rather than only controls created by the latest synchronization.
 
 #### Scenario: Panel retains a valid graph
 - **WHEN** at least one graph mapped to a panel remains active

--- a/openspec/changes/repair-ribbon-graph-synchronization/tasks.md
+++ b/openspec/changes/repair-ribbon-graph-synchronization/tasks.md
@@ -1,15 +1,16 @@
 ## 1. State Model
 
-- [ ] 1.1 Add typed discovery snapshot and ribbon registry models under `src/Classes` or `src/Utilities`
-- [ ] 1.2 Extract normalized graph discovery and snapshot comparison from `RibbonUtils.SyncGraphs`
-- [ ] 1.3 Add or reuse a Relay test project and cover unchanged, added, removed, duplicate-name, and failed-discovery snapshots
+- [ ] 1.1 Add typed graph snapshot, tab-and-panel identity, reconciliation plan, and active/historical registry models
+- [ ] 1.2 Extract complete normalized graph discovery and pure snapshot comparison from `RibbonUtils.SyncGraphs`
+- [ ] 1.3 Extend `tests/Relay.Tests` for unchanged, added, removed, restored, duplicate-name, same-panel-name, and failed-discovery snapshots
 
 ## 2. Ribbon Reconciliation
 
-- [ ] 2.1 Refactor `RibbonUtils.AddItems` to append successful controls to complete panel membership
-- [ ] 2.2 Refactor `RibbonUtils.HideUnused` into a two-phase reconciliation that never mutates a collection during enumeration
-- [ ] 2.3 Preserve graph metadata across Revit and Autodesk ribbon wrappers and restore valid panel visibility
-- [ ] 2.4 Verify repeated Sync, add, remove, rename, and empty-panel behavior in Revit 2025, 2026, and 2027
+- [x] 2.1 Append every successfully created control to cumulative panel membership without replacing existing entries
+- [ ] 2.2 Replace per-file `File.Exists` cleanup with snapshot-based two-phase reconciliation applied only after complete discovery
+- [ ] 2.3 Replace tooltip-derived synchronization identity with normalized Relay-owned graph, tab, panel, and host-control mappings
+- [ ] 2.4 Reactivate reusable historical controls and derive panel visibility from complete tab-and-panel membership
+- [ ] 2.5 Verify repeated Sync, add, remove, restore, rename, duplicate panel names, and empty-panel behavior in Revit 2025, 2026, and 2027
 
 ## 3. Validation
 


### PR DESCRIPTION
## What changed

- Reconciles the active ribbon synchronization proposal with the fixes merged in PR #35.
- Marks cumulative panel membership as completed baseline work.
- Refocuses remaining implementation on complete discovery snapshots, typed reconciliation plans, composite tab/panel identities, and historical-control reuse.
- Clarifies the specification for atomic discovery and same-path graph restoration.
- Updates the task list to extend the existing Relay test project rather than creating duplicate infrastructure.

## Why

PR #35 fixed the immediate Sync Graphs regression, but the original OpenSpec artifacts still described those baseline defects as unimplemented. This update makes the proposal, design, requirements, and tasks coherent with current `master` before implementation continues.

## Impact

Planning artifacts only; no application code changes.

## Validation

- `openspec validate repair-ribbon-graph-synchronization --strict`
- `git diff --check`
