### PR TITLE
Specify dynamic Dynamo graph input UI

### DIFF
--- a/openspec/changes/add-dynamic-graph-input-ui/.openspec.yaml
+++ b/openspec/changes/add-dynamic-graph-input-ui/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-14

--- a/openspec/changes/add-dynamic-graph-input-ui/design.md
+++ b/openspec/changes/add-dynamic-graph-input-ui/design.md
@@ -1,0 +1,95 @@
+## Context
+
+Relay currently resolves one graph path and invokes `DynamoMethods.RunGraph`. The runner creates an automatic temporary copy, loads DynamoRevit through reflection, and immediately forces evaluation. Dynamo graph authors already identify player-facing fields with `IsInput`, but Relay neither interprets those declarations nor has a pause between graph load and evaluation where document-backed input state can be applied.
+
+Primitive values can often be read from and written to graph JSON. Revit dropdowns such as Categories are different: their options are supplied by the active Revit/Dynamo environment, display names may be localized, and serialized indices are not stable identities across versions. The input feature therefore needs a version-neutral Relay model plus a version-specific runtime binding boundary.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Honor Dynamo's existing `IsInput` authoring convention.
+- Support primitive, path, slider, and Revit Categories inputs in the initial compatibility matrix.
+- Keep input discovery and validation testable without Revit wherever possible.
+- Bind Categories through stable identities and the active version adapter.
+- Prevent evaluation until all required accepted bindings are applied.
+- Preserve direct execution for graphs with no declared inputs.
+
+**Non-Goals:**
+
+- Clone Dynamo Player, render graph outputs, or support arbitrary custom input UI.
+- Treat localized labels, selected indices, or node positions as durable identities.
+- Persist values between runs or alter source graphs.
+- Expand the initial contract to Levels, Views, Element Types, or element selection without a later compatibility decision.
+
+## Decisions
+
+1. Parse `.dyn` JSON before execution and map nodes marked `IsInput` to version-neutral `GraphInputDescriptor` values keyed by node GUID. Discovery records the concrete Dynamo node identity and serialized binding metadata but exposes only Relay input kinds to the UI.
+2. Use an explicit supported-node registry per Dynamo adapter. The initial kinds are string, number, boolean, integer slider, number slider, file path, directory path, and Revit Categories. An unknown or unsupported declared input is represented explicitly; Relay does not guess a control from its current JSON value.
+3. Generate one Relay-owned WPF dialog from immutable descriptors and return a typed accepted, cancelled, or invalid result. UI controls bind to view models rather than Dynamo or Revit objects so validation can be unit tested.
+4. Treat a supported declared input with no valid value as blocking. Treat an unsupported declared input as blocking by default because silently evaluating with an old or default value would make the dialog misleading. The dialog identifies every blocking node by its custom name and input kind.
+5. Bind JSON-safe primitive and path values only to the disposable temporary graph. Never update the source `.dyn`. The binder addresses nodes by GUID and verifies the expected concrete type before changing node-specific fields.
+6. Represent a category choice with stable host identity plus localized display text. Display text and dropdown index are never the durable binding key. The active Dynamo adapter resolves the stable category identity against the instantiated Categories node and applies the matching runtime item before evaluation.
+7. Split execution into prepare, load, bind, and evaluate stages behind an `IDynamoExecutionSession`. Loading MUST NOT evaluate the graph. The session validates all bindings atomically enough that a failure prevents evaluation; it reports which node and compatibility boundary rejected the value.
+8. Obtain Categories choices from the runtime node through the version adapter when that callable surface is available, because it most closely matches the installed Dynamo version. A direct Revit category provider may be used only if host verification proves the resulting stable identities and supported set are equivalent; adapters own this policy.
+9. Keep all Revit and Dynamo access on the valid external-command/UI thread. The input window is modal to the Relay command. Cancellation closes the execution session, cleans the temporary graph, and returns `Result.Cancelled` without updating successful-document lifecycle state.
+10. Graphs with no `IsInput` declarations bypass the dialog and use the same staged runner with an empty binding set. This preserves current user-visible behavior while keeping one execution path.
+
+## Data Flow
+
+```text
+registered graph activation
+          |
+          v
+parse IsInput declarations ---- invalid JSON ----> failed command
+          |
+          v
+prepare temporary graph
+          |
+          v
+load paused Dynamo session
+          |
+          +---- adapter supplies Categories choices
+          |
+          v
+generated WPF dialog ---- cancel ----> dispose session and temporary graph
+          |
+          v
+validate typed values
+          |
+          v
+apply JSON and runtime bindings ---- binding failure ----> no evaluation
+          |
+          v
+evaluate graph ----> outcome ----> cleanup
+```
+
+## Compatibility Matrix
+
+Each supported Revit/Dynamo adapter documents and host-tests:
+
+- Recognized concrete node identities for each Relay input kind.
+- Serialized fields used for primitive discovery and temporary-copy binding.
+- Runtime members used to enumerate and select Categories items.
+- Stable Revit category identity conversion in both directions.
+- Behavior when a graph was authored by a different compatible Dynamo version.
+
+Missing or incompatible members fail adapter validation with an actionable diagnostic. Relay does not fall back to a selected index or localized name.
+
+## Risks / Trade-offs
+
+- [Dynamo initializes before confirmation] -> Load only when runtime-backed choices are required; primitive-only graphs can show the dialog before session creation if this does not split observable behavior.
+- [Runtime dropdown APIs are internal] -> Isolate reflection in small version adapters and validate members before showing an actionable Categories control.
+- [Category set changes with document or version] -> Generate choices for the active execution context and revalidate the stable identity immediately before binding.
+- [Mixed unsupported inputs confuse users] -> Show all declared inputs and block execution with node-specific compatibility feedback.
+- [Temporary JSON and runtime state diverge] -> Use one typed binding set and verify node GUID, expected kind, and accepted value at each binding stage.
+
+## Migration Plan
+
+Implement after the staged execution boundary from `harden-dynamo-graph-execution` is available. Existing graphs require no migration: graphs without `IsInput` continue to run directly, and graphs already prepared for Dynamo Player become eligible for Relay controls according to the supported-node matrix. Rollback removes the pre-run dialog and passes an empty binding set through the hardened runner; source graphs and persisted settings remain unchanged.
+
+## Open Questions
+
+- Confirm the exact runtime members for enumerating and selecting Categories in Dynamo 3.0, 3.6, and 4.0 during adapter implementation.
+- Decide whether a later change should add Levels, Views, Element Types, and Revit element selection to the supported matrix.
+- Decide whether primitive-only graphs should avoid Dynamo initialization until after the user accepts the dialog, provided lifecycle and diagnostics remain consistent.

--- a/openspec/changes/add-dynamic-graph-input-ui/proposal.md
+++ b/openspec/changes/add-dynamic-graph-input-ui/proposal.md
@@ -1,0 +1,57 @@
+## Why
+
+Relay runs Dynamo graphs from ribbon buttons without giving users a way to supply values for nodes that graph authors mark as inputs. Users must open Dynamo or maintain duplicate graphs for values that Dynamo Player can request at run time, including document-backed choices such as Categories.
+
+## Problem
+
+Relay treats execution as one opaque operation: select a graph, prepare an automatic temporary copy, and run it. It does not discover `IsInput` nodes, present compatible controls, validate user values, or bind document-dependent selections before evaluation. Static JSON substitution alone is insufficient for Revit dropdown nodes whose choices and runtime values depend on the active host and Dynamo version.
+
+## Scope
+
+- Discover Dynamo nodes marked `IsInput` and map supported nodes to typed Relay input descriptors.
+- Generate a Relay-owned WPF dialog for supported primitive, path, slider, and Revit Categories inputs.
+- Populate Categories choices from the active Revit/Dynamo execution context and retain a stable category identity independent of display text and list position.
+- Bind accepted values to the temporary graph or staged Dynamo workspace before graph evaluation.
+- Report unsupported, invalid, stale, and unbindable inputs without modifying the source graph.
+- Define cancellation and lifecycle behavior from graph activation through execution cleanup.
+
+## Non-goals
+
+- Reproducing the complete Dynamo Player interface or every input node it supports.
+- Supporting arbitrary third-party nodes merely because they are marked `IsInput`.
+- Persisting input presets or writing accepted values back to source `.dyn` files.
+- Displaying graph outputs or progress in the first release.
+- Changing graph discovery, ribbon synchronization, or graph-command routing semantics.
+
+## What Changes
+
+- Add pure graph-input discovery and a typed, version-neutral input model keyed by Dynamo node GUID.
+- Add a generated WPF input dialog with validation and explicit unsupported-input feedback.
+- Add a Revit Categories choice provider and version-specific Dynamo binding for the selected stable category identity.
+- Extend the hardened Dynamo execution seam to load a prepared graph, apply accepted bindings, and only then evaluate it.
+- Add focused tests plus Revit 2025-2027 host verification for input discovery, dialog outcomes, binding, cancellation, and cleanup.
+
+## Capabilities
+
+### New Capabilities
+
+- `dynamic-graph-input-ui`: Defines discovery, presentation, validation, and binding of supported Dynamo graph inputs before Relay executes a graph.
+
+### Modified Capabilities
+
+- `dynamo-graph-execution`: Staged execution must permit validated inputs to be applied after graph load and before evaluation.
+
+## Risks
+
+- Dynamo node serialization and runtime input APIs can differ across Dynamo 3.0, 3.6, and 4.0.
+- Revit category display names are localized and dropdown ordering is not a stable binding identity.
+- Opening a graph to obtain document-backed choices may initialize Dynamo before the user commits to run it.
+- A graph can mix supported, unsupported, disconnected, and invalid input nodes in ways that require an explicit run policy.
+
+## Compatibility
+
+Must cover Revit 2025 with Dynamo 3.0, Revit 2026 with Dynamo 3.6, and Revit 2027 with the configured Dynamo 4.0 integration. Relay uses an explicit supported-node matrix per adapter and MUST NOT infer compatibility from display names or reflected type names alone.
+
+## Impact
+
+Affects `src/Command.cs`, new graph-input domain and discovery components, new WPF views/view models, Revit-backed choice providers, `src/Methods/DynamoMethods.cs`, Dynamo version adapters introduced by `harden-dynamo-graph-execution`, diagnostics, and test projects. Users see an input dialog after activating a graph with supported or declared inputs; graphs without declared inputs retain direct execution behavior.

--- a/openspec/changes/add-dynamic-graph-input-ui/specs/dynamic-graph-input-ui/spec.md
+++ b/openspec/changes/add-dynamic-graph-input-ui/specs/dynamic-graph-input-ui/spec.md
@@ -1,0 +1,128 @@
+## ADDED Requirements
+
+### Requirement: Relay discovers declared graph inputs
+
+Relay SHALL inspect a selected graph for Dynamo nodes marked `IsInput` and produce typed input descriptors keyed by node GUID before graph evaluation.
+
+#### Scenario: Graph contains supported declared inputs
+- **WHEN** a valid graph contains nodes marked `IsInput` whose concrete node identities are supported by the active adapter
+- **THEN** Relay produces one descriptor for each declared input
+- **AND** preserves its node GUID, display label, input kind, current value, and binding metadata
+
+#### Scenario: Graph contains an unsupported declared input
+- **WHEN** a node marked `IsInput` is not in the active adapter's supported-node matrix
+- **THEN** Relay represents that node as unsupported with its node GUID and display label
+- **AND** MUST NOT infer a writable input kind from display text or serialized value alone
+
+#### Scenario: Graph has no declared inputs
+- **WHEN** a valid graph contains no nodes marked `IsInput`
+- **THEN** Relay bypasses the input dialog
+- **AND** continues through the standard staged execution path with an empty binding set
+
+#### Scenario: Input declaration cannot be parsed
+- **WHEN** the graph JSON or a declared input's required identity is invalid
+- **THEN** Relay returns a failed command outcome with graph and node context when available
+- **AND** Dynamo evaluation does not begin
+
+### Requirement: Relay presents and validates supported inputs
+
+Relay SHALL generate a modal input dialog for declared graph inputs and SHALL validate supported values before applying any binding.
+
+#### Scenario: User accepts valid values
+- **WHEN** every supported required input has a valid value and no declared input is unsupported
+- **THEN** Relay returns one typed binding per supported node GUID
+- **AND** proceeds to input application
+
+#### Scenario: Required value is invalid
+- **WHEN** a supported required input is empty, out of range, or otherwise invalid for its descriptor
+- **THEN** Relay identifies the invalid field in the dialog
+- **AND** MUST NOT apply bindings or evaluate the graph
+
+#### Scenario: Declared input is unsupported
+- **WHEN** the dialog contains an unsupported declared input
+- **THEN** Relay identifies the unsupported node and active compatibility boundary
+- **AND** blocks graph execution
+
+#### Scenario: User cancels input
+- **WHEN** the user cancels or closes the input dialog
+- **THEN** Relay returns `Result.Cancelled`
+- **AND** applies no bindings, performs no graph evaluation, and cleans up owned execution resources
+
+### Requirement: Relay supports the initial input compatibility matrix
+
+Relay MUST support string, number, boolean, integer slider, number slider, file path, directory path, and Revit Categories inputs when the corresponding node identity is supported by the active adapter.
+
+#### Scenario: Primitive or path input is accepted
+- **WHEN** a user accepts a valid primitive, slider, or path value
+- **THEN** Relay binds that value to the matching node GUID in the temporary graph
+- **AND** leaves the source graph byte-for-byte unchanged
+
+#### Scenario: Slider value violates its bounds
+- **WHEN** a supplied slider value is outside the bounds declared by the graph input
+- **THEN** Relay rejects the value before graph evaluation
+- **AND** reports the permitted range
+
+#### Scenario: Path value is invalid
+- **WHEN** a required file or directory value does not satisfy the descriptor's path validation
+- **THEN** Relay rejects the value before graph evaluation
+- **AND** reports the affected input without modifying either graph file
+
+### Requirement: Relay binds Revit Categories by stable identity
+
+Relay SHALL populate a Categories input from the active Revit/Dynamo execution context and SHALL bind the selected category using a stable host identity rather than display text or dropdown position.
+
+#### Scenario: Categories choices are available
+- **WHEN** a supported Categories node is declared as input and the active adapter can enumerate its runtime choices
+- **THEN** Relay displays the available localized category names
+- **AND** retains a stable identity for each choice
+
+#### Scenario: User selects a category
+- **WHEN** the user accepts a category choice
+- **THEN** the active adapter resolves its stable identity against the matching instantiated node GUID
+- **AND** applies the corresponding runtime dropdown item before evaluation
+
+#### Scenario: Category becomes stale
+- **WHEN** the selected stable category identity is no longer available in the active execution context at binding time
+- **THEN** Relay rejects the binding with node and category context
+- **AND** MUST NOT fall back to a matching display name or dropdown index
+- **AND** does not evaluate the graph
+
+#### Scenario: Categories runtime surface is incompatible
+- **WHEN** the active adapter cannot enumerate or select Categories items using its validated binding surface
+- **THEN** Relay reports Categories as unsupported for that compatibility boundary
+- **AND** does not evaluate the graph
+
+### Requirement: Relay applies inputs before graph evaluation
+
+Relay SHALL load the prepared graph without evaluation, apply all accepted input bindings, and evaluate the graph only after every binding succeeds.
+
+#### Scenario: Every binding succeeds
+- **WHEN** all accepted values match their expected node GUIDs and kinds and the active adapter applies all runtime bindings
+- **THEN** Relay evaluates the graph once with the accepted inputs
+
+#### Scenario: A binding target does not match
+- **WHEN** a node GUID is missing or its concrete node identity no longer matches the discovered descriptor
+- **THEN** Relay returns a failed execution outcome naming the affected input
+- **AND** does not evaluate the graph
+
+#### Scenario: Binding fails after graph load
+- **WHEN** any JSON or runtime binding cannot be applied after the execution session is created
+- **THEN** Relay does not evaluate the graph
+- **AND** disposes the session and temporary graph according to the execution cleanup contract
+
+### Requirement: Input behavior is version validated
+
+Relay MUST validate input discovery and binding behavior for Revit 2025/Dynamo 3.0, Revit 2026/Dynamo 3.6, and Revit 2027/Dynamo 4.0 through isolated adapters.
+
+#### Scenario: Supported adapter is active
+- **WHEN** Relay runs a graph with declared inputs in a supported host version
+- **THEN** it uses only node identities, serialized fields, and runtime members validated for that adapter
+
+#### Scenario: Graph input differs across supported versions
+- **WHEN** a node's serialization or runtime binding surface differs between supported Dynamo versions
+- **THEN** each adapter translates that version into the same Relay input descriptor and binding outcome semantics
+
+#### Scenario: Required version binding is missing
+- **WHEN** an adapter lacks a required input member or compatible signature
+- **THEN** Relay fails with an actionable compatibility diagnostic
+- **AND** does not evaluate the graph

--- a/openspec/changes/add-dynamic-graph-input-ui/tasks.md
+++ b/openspec/changes/add-dynamic-graph-input-ui/tasks.md
@@ -1,0 +1,36 @@
+## 1. Input Domain and Discovery
+
+- [ ] 1.1 Add immutable graph-input descriptors, typed values, binding results, dialog outcomes, and an explicit supported-node registry keyed by version adapter
+- [ ] 1.2 Implement pure `.dyn` JSON discovery for `IsInput` nodes, node GUIDs, custom labels, current values, slider bounds, path metadata, and concrete node identities
+- [ ] 1.3 Implement temporary-graph binding for supported string, number, boolean, slider, file path, and directory path nodes with node identity revalidation
+- [ ] 1.4 Add focused tests for supported, unsupported, malformed, duplicate-label, missing-GUID, range, path, source-immutability, and semantic-preservation cases
+
+## 2. Generated Input UI
+
+- [ ] 2.1 Add WPF input view models and a modal generated dialog for the initial supported input kinds
+- [ ] 2.2 Add per-control validation, blocking unsupported-input feedback, accepted typed bindings, and explicit cancellation behavior
+- [ ] 2.3 Wire `Relay.Run` to bypass the dialog for no-input graphs and request values for graphs with declared inputs without introducing global pending-input state
+- [ ] 2.4 Test view-model generation, validation, acceptance, cancellation, mixed supported/unsupported inputs, and duplicate display labels independently of Revit
+
+## 3. Revit Categories Integration
+
+- [ ] 3.1 Define a stable Revit category choice model and adapter-owned enumeration/binding boundary that never uses localized names or indices as durable identity
+- [ ] 3.2 Implement Categories enumeration and runtime selection for Revit 2025/Dynamo 3.0
+- [ ] 3.3 Implement Categories enumeration and runtime selection for Revit 2026/Dynamo 3.6
+- [ ] 3.4 Confirm and implement Categories enumeration and runtime selection for Revit 2027/Dynamo 4.0
+- [ ] 3.5 Add adapter tests for choice mapping, stale identities, missing nodes, mismatched concrete types, unavailable members, and binding failure before evaluation
+
+## 4. Staged Execution and Lifecycle
+
+- [ ] 4.1 Integrate input discovery and accepted bindings with the staged execution session introduced by `harden-dynamo-graph-execution`
+- [ ] 4.2 Guarantee graph load remains paused until all JSON and runtime bindings succeed, then evaluate exactly once
+- [ ] 4.3 Dispose Dynamo session and temporary graph resources on dialog cancellation, validation failure, binding failure, invocation failure, and success
+- [ ] 4.4 Verify failed or cancelled input collection does not advance the last-successful-document lifecycle marker
+
+## 5. Host and Build Validation
+
+- [ ] 5.1 Host-test no-input, primitive-only, Categories, mixed unsupported, cancellation, stale-category, and binding-failure graphs in Revit 2025, 2026, and 2027
+- [ ] 5.2 Document the supported concrete node identities, serialized fields, and runtime members for each Dynamo adapter
+- [ ] 5.3 Run focused input discovery, UI view-model, graph binding, adapter, lifecycle, and cleanup tests
+- [ ] 5.4 Build `src/Relay.sln` with `Debug R25`, `Debug R26`, and `Debug R27`
+- [ ] 5.5 Run strict OpenSpec validation and record the host compatibility results

--- a/openspec/changes/harden-dynamo-graph-execution/design.md
+++ b/openspec/changes/harden-dynamo-graph-execution/design.md
@@ -1,6 +1,6 @@
 ## Context
 
-`DynamoMethods.RunGraph` creates a temporary graph via literal text replacement, locates an assembly whose name contains `DynamoRevitDS`, and invokes unchecked reflected members. Temporary cleanup is reliable, but preparation and binding failures have little context and the document lifecycle marker is coupled to successful reflection calls.
+`DynamoMethods.RunGraph` creates a temporary graph via literal text replacement, locates an assembly whose name contains `DynamoRevitDS`, and invokes unchecked reflected members. It loads and forces evaluation as one opaque operation, so a later input workflow has no validated point at which to inspect a loaded workspace, apply document-backed bindings, or cancel before evaluation. Temporary cleanup is reliable, but preparation and binding failures have little context and the document lifecycle marker is coupled to successful reflection calls.
 
 ## Goals / Non-Goals
 
@@ -8,31 +8,37 @@
 
 - Preserve source graphs while preparing a structurally valid automatic-run copy.
 - Validate the Dynamo adapter before invocation and report incompatibility clearly.
+- Provide prepare, load, bind, and evaluate stages without evaluating during graph load.
 - Define model reuse across documents and guarantee cleanup.
 
 **Non-Goals:**
 
 - Replace DynamoRevit, install packages, or guarantee third-party node compatibility.
-- Introduce dynamic graph input UI.
+- Discover or present dynamic graph inputs; this change defines only typed binding and staged execution boundaries.
 
 ## Decisions
 
 1. Parse the `.dyn` document with `JsonNode`/`JsonDocument` semantics and update only the top-level `RunType`, writing a new temporary file. Literal replacement is rejected because formatting or a missing comma changes behavior silently.
-2. Define an `IDynamoRunner` boundary with one adapter per materially different DynamoRevit surface. Reflection remains isolated where public compile-time APIs cannot span versions. Each adapter validates assembly identity, required types, members, and compatible signatures before invocation.
-3. Return a typed execution outcome that maps expected failures to a Revit `Result` and detailed diagnostic. Unexpected exceptions retain stack/context and are not converted to success.
-4. Track the last successfully attached Revit document via weak reference. A document change requests model shutdown/reinitialization according to the version adapter; failed runs do not advance lifecycle state.
-5. Own the temporary graph with `IDisposable`-style cleanup so every exit path attempts deletion and reports cleanup failure separately.
+2. Define an `IDynamoRunner` that creates an `IDynamoExecutionSession` through one adapter per materially different DynamoRevit surface. The session exposes validated load, bind, and evaluate stages; graph load MUST remain paused until the caller explicitly evaluates it. Direct graph execution passes an empty binding set through the same path.
+3. Keep typed binding contracts version-neutral and keyed by Dynamo node GUID. The hardening layer does not discover inputs or interpret UI values; it validates that each supplied binding targets the expected runtime node and delegates version-specific mutation to the adapter.
+4. Isolate reflection where public compile-time APIs cannot span versions. Each adapter validates assembly identity, required types, execution members, input-binding members, and compatible signatures before the relevant stage.
+5. Return typed preparation, load, binding, invocation, cancellation, and cleanup outcomes that map to a Revit `Result` and detailed diagnostic. Unexpected exceptions retain stack/context and are not converted to success.
+6. Track the last successfully attached Revit document via weak reference. A document change requests model shutdown/reinitialization according to the version adapter; failed or cancelled sessions do not advance lifecycle state.
+7. Make the execution session and temporary graph disposable owners. Cancellation or failure before evaluation closes any staged model/workspace state and attempts temporary-file deletion; cleanup failure is reported separately from the primary outcome.
 
 ## Risks / Trade-offs
 
 - [Reflected Dynamo surface changes] -> Keep adapters small, validate eagerly, and host-test each supported matrix entry.
+- [A loaded graph evaluates before bindings are applied] -> Configure and verify paused load in every adapter, and expose evaluation as an explicit one-shot operation.
+- [Partially applied bindings leave ambiguous state] -> Prevent evaluation after any binding failure and dispose the entire execution session.
 - [JSON serialization changes formatting] -> Operate only on the temporary copy and verify semantic preservation in tests.
 - [Model shutdown policy loses performance] -> Prefer correctness across documents; measure before introducing reuse optimization.
 
 ## Migration Plan
 
-Introduce the runner boundary behind the existing `RunGraph` entry point, then migrate one supported version at a time. Rollback can restore the prior runner without changing graph files or settings.
+Introduce the staged runner and session boundary behind the existing `RunGraph` entry point, pass an empty binding set for current callers, then migrate one supported version at a time. The later dynamic-input change can supply typed bindings without replacing the lifecycle contract. Rollback can restore the prior runner without changing graph files or settings.
 
 ## Open Questions
 
 - Confirm the final DynamoRevit package/version and callable surface shipped with Revit 2027 before locking that adapter.
+- Confirm the paused-load and runtime node-binding members available in Dynamo 3.0, 3.6, and 4.0 before finalizing each session adapter.

--- a/openspec/changes/harden-dynamo-graph-execution/proposal.md
+++ b/openspec/changes/harden-dynamo-graph-execution/proposal.md
@@ -10,6 +10,7 @@ Graph preparation, Dynamo discovery, reflective API binding, model lifecycle pol
 
 - Parse and update the graph run mode structurally without modifying the source graph.
 - Validate DynamoRevit assembly, types, properties, and methods before invocation.
+- Provide a staged execution session that can load a graph without evaluation, accept validated typed bindings, and evaluate only after binding succeeds.
 - Define Dynamo model reuse and shutdown behavior across active Revit documents.
 - Convert preparation and invocation failures into explicit Relay command results and diagnostics.
 - Always clean up temporary graph files.
@@ -18,11 +19,12 @@ Graph preparation, Dynamo discovery, reflective API binding, model lifecycle pol
 
 - Replacing DynamoRevit's supported journal-command execution mechanism.
 - Managing third-party Dynamo package installation.
-- Implementing dynamic graph input UI.
+- Implementing dynamic graph input discovery or UI; this change provides only the staged execution and binding seam they require.
 
 ## What Changes
 
 - Extract graph preparation and reflective binding behind testable components.
+- Split graph execution into validated prepare, load, bind, and evaluate stages while preserving direct execution with an empty binding set.
 - Fail clearly when DynamoRevit is unavailable or incompatible.
 - Track document/model lifecycle only after a successful execution transition.
 - Add version-focused tests and host verification for Revit 2025-2027.
@@ -39,7 +41,7 @@ None.
 
 ## Risks
 
-- DynamoRevit's internal/reflected surface can differ by bundled Dynamo release.
+- DynamoRevit's internal/reflected execution and input-binding surfaces can differ by bundled Dynamo release.
 - Structural JSON writes must preserve graph fields Relay does not understand.
 
 ## Compatibility
@@ -48,4 +50,4 @@ Must cover Dynamo 3.0 with Revit 2025, Dynamo 3.6 with Revit 2026, and the confi
 
 ## Impact
 
-Affects `src/Methods/DynamoMethods.cs`, `src/Utilities/DynamoUtils.cs`, `src/Command.cs`, JSON handling, diagnostics, and execution tests.
+Affects `src/Methods/DynamoMethods.cs`, `src/Utilities/DynamoUtils.cs`, `src/Command.cs`, staged execution and binding contracts, JSON handling, diagnostics, and execution tests. The later `add-dynamic-graph-input-ui` change consumes these contracts.

--- a/openspec/changes/harden-dynamo-graph-execution/specs/dynamo-graph-execution/spec.md
+++ b/openspec/changes/harden-dynamo-graph-execution/specs/dynamo-graph-execution/spec.md
@@ -16,16 +16,46 @@ Relay SHALL create a temporary copy of the selected graph and set its top-level 
 
 ### Requirement: Dynamo compatibility is validated before invocation
 
-Relay MUST validate the required DynamoRevit assembly, types, members, and signatures for the active supported Revit version before invoking a graph.
+Relay MUST validate the required DynamoRevit assembly, types, staged execution members, input-binding members, and signatures for the active supported Revit version before using the relevant graph execution stage.
 
 #### Scenario: Compatible DynamoRevit is loaded
 - **WHEN** all required adapter bindings are available
-- **THEN** Relay invokes the graph using the adapter for the active Revit version
+- **THEN** Relay loads, binds, and invokes the graph using the adapter for the active Revit version
 
 #### Scenario: DynamoRevit is unavailable or incompatible
 - **WHEN** any required binding is missing or has an incompatible signature
 - **THEN** Relay returns a failed command result
 - **AND** reports the missing compatibility boundary without a null-reference failure
+
+### Requirement: Graph execution is staged before evaluation
+
+Relay SHALL expose graph preparation, paused load, typed binding, and evaluation as ordered execution stages and SHALL NOT evaluate a graph merely by loading it.
+
+#### Scenario: Graph is loaded for direct execution
+- **WHEN** a prepared graph has no supplied input bindings
+- **THEN** Relay loads it without evaluation
+- **AND** evaluates it once only after the empty binding set is accepted
+
+#### Scenario: Graph is loaded for input binding
+- **WHEN** a caller supplies validated typed bindings keyed by Dynamo node GUID
+- **THEN** Relay loads the prepared graph without evaluation
+- **AND** applies every binding before requesting evaluation
+
+#### Scenario: Binding target is invalid
+- **WHEN** a supplied node GUID is missing or does not have the expected runtime node identity
+- **THEN** Relay returns a failed binding outcome with node and adapter context
+- **AND** does not evaluate the graph
+
+#### Scenario: Binding application fails
+- **WHEN** any adapter cannot apply a supplied value through its validated binding surface
+- **THEN** Relay reports the binding failure separately from invocation
+- **AND** does not evaluate the graph
+
+#### Scenario: Execution is cancelled before evaluation
+- **WHEN** the caller cancels after preparation or load but before evaluation
+- **THEN** Relay returns a cancelled execution outcome
+- **AND** performs no graph evaluation
+- **AND** disposes the staged execution session and temporary graph
 
 ### Requirement: Dynamo model lifecycle follows the active document
 
@@ -43,6 +73,10 @@ Relay SHALL reuse or shut down Dynamo model state according to the last successf
 - **WHEN** graph invocation does not complete successfully
 - **THEN** Relay MUST NOT record that document as the last successful execution document
 
+#### Scenario: Execution is cancelled before evaluation
+- **WHEN** a staged execution session is cancelled before graph evaluation
+- **THEN** Relay MUST NOT record that document as the last successful execution document
+
 ### Requirement: Temporary execution files are cleaned up
 
 Relay SHALL attempt to delete every temporary graph copy on success, failure, or cancellation.
@@ -51,3 +85,8 @@ Relay SHALL attempt to delete every temporary graph copy on success, failure, or
 - **WHEN** Dynamo invocation returns or throws
 - **THEN** Relay attempts temporary-file deletion
 - **AND** reports a cleanup failure separately from the graph execution outcome
+
+#### Scenario: Staged session exits before invocation
+- **WHEN** graph load, binding, or caller cancellation ends a session before evaluation
+- **THEN** Relay closes owned session state and attempts temporary-file deletion
+- **AND** reports cleanup failures separately from the load, binding, or cancellation outcome

--- a/openspec/changes/harden-dynamo-graph-execution/tasks.md
+++ b/openspec/changes/harden-dynamo-graph-execution/tasks.md
@@ -6,20 +6,21 @@
 
 ## 2. Dynamo Adapter
 
-- [ ] 2.1 Define typed Dynamo runner, binding validation, and execution outcome boundaries
-- [ ] 2.2 Implement and validate the Revit 2025/Dynamo 3.0 adapter
-- [ ] 2.3 Implement and validate the Revit 2026/Dynamo 3.6 adapter
-- [ ] 2.4 Confirm the Revit 2027 Dynamo surface and implement its isolated adapter
-- [ ] 2.5 Map preparation, compatibility, invocation, and cancellation outcomes to Revit command results and diagnostics
+- [ ] 2.1 Define typed Dynamo runner, disposable execution session, version-neutral node-GUID binding, adapter validation, and execution outcome boundaries
+- [ ] 2.2 Implement and validate paused load, empty binding, explicit one-shot evaluation, and cleanup in the Revit 2025/Dynamo 3.0 adapter
+- [ ] 2.3 Implement and validate paused load, empty binding, explicit one-shot evaluation, and cleanup in the Revit 2026/Dynamo 3.6 adapter
+- [ ] 2.4 Confirm the Revit 2027 staged execution and runtime binding surface and implement its isolated adapter
+- [ ] 2.5 Validate expected runtime node identity before applying a supplied binding and prevent evaluation after any binding failure
+- [ ] 2.6 Map preparation, load, compatibility, binding, invocation, cancellation, and cleanup outcomes to Revit command results and diagnostics
 
 ## 3. Lifecycle and Host Verification
 
 - [ ] 3.1 Refactor document/model tracking so only successful runs update the weak document reference
-- [ ] 3.2 Test same-document reuse, document changes, failed runs, and missing/incompatible reflection members
-- [ ] 3.3 Verify successful, invalid-graph, unavailable-Dynamo, and cross-document runs in Revit 2025, 2026, and 2027
+- [ ] 3.2 Test same-document reuse, document changes, failed or cancelled staged sessions, and missing/incompatible execution or binding members
+- [ ] 3.3 Verify successful, invalid-graph, unavailable-Dynamo, paused-load, binding-failure, cancellation, and cross-document runs in Revit 2025, 2026, and 2027
 
 ## 4. Validation
 
-- [ ] 4.1 Run focused graph-preparation, adapter, and lifecycle tests
+- [ ] 4.1 Run focused graph-preparation, staged adapter, binding-validation, cancellation, cleanup, and lifecycle tests
 - [ ] 4.2 Build `src/Relay.sln` with `Debug R25`, `Debug R26`, and `Debug R27`
 - [ ] 4.3 Run strict OpenSpec validation and record host compatibility results


### PR DESCRIPTION
## What changed

- add a complete OpenSpec proposal, design, requirements, and task plan for dynamic Dynamo graph input UI
- define initial support for primitive, path, slider, and Revit Categories inputs marked with Dynamo's `IsInput` convention
- update the hardened Dynamo execution change with paused load, typed node-GUID binding, explicit evaluation, cancellation, and cleanup boundaries

## Why

Relay currently runs a selected Dynamo graph as one opaque operation and cannot collect or bind document-dependent input values before evaluation. Revit dropdowns such as Categories require stable host identities and version-specific Dynamo bindings rather than localized labels or serialized list indices.

## Impact

This PR changes planning artifacts only. It separates Relay-owned input discovery and WPF UI from the staged Dynamo execution seam, defines compatibility expectations for Revit 2025-2027, and provides implementation and host-validation tasks. No application behavior changes yet.

## Validation

- `npx -y @fission-ai/openspec@1.6.0 validate --all --strict --no-interactive` (8 passed, 0 failed)
- `git diff --cached --check`
